### PR TITLE
add batches, to allow emulation of syscon perf testing method

### DIFF
--- a/api_gateway_perf_test.rb
+++ b/api_gateway_perf_test.rb
@@ -4,33 +4,47 @@ require 'byebug'
 
 require_relative './gen_auth'
 require_relative './command_line_parser'
-require_relative './httparty_adapter'
-require_relative './api_request'
+require_relative './request_group'
 require_relative './responses_printer'
+require_relative './batches'
 
 BASE_URL              = ENV['NOMIS_API_BASE_URL'] || 'https://noms-api-preprod.dsd.io/nomisapi'
-ENDPOINT_1            = "#{BASE_URL}/health".freeze
-ENDPOINT_2            = "#{BASE_URL}/foobar".freeze
-
-puts opts = CommandLineParser.parse_opts
+ENDPOINT_1            = "#{BASE_URL}/foobar".freeze
 
 threads = []
 responses = []
 
+OPTS = CommandLineParser.parse_opts
+
 ResponsesPrinter.print_heading
 
-opts[:concurrent_users].times.each do |_|
+chosen_batches = OPTS[:batches] || ['default']
+batches_to_run = chosen_batches.map { |b| BATCHES[b.to_sym] }.flatten.compact
+# allow default batch to take some measures from the cmd line param
+default_batch_opts = {
+  number_of_users: OPTS[:concurrent_users],
+  url: (OPTS[:url] || ENDPOINT_1),
+  interval_between_requests: OPTS[:interval_between_requests].to_i,
+  interval_between_users: OPTS[:rampup_per_user].to_i
+}
+
+# start of main loop
+batches_to_run.each do |batch_config|
+  # create a thread for each batch
+  this_batch = default_batch_opts.merge(batch_config)
+  batch = RequestGroup.new(this_batch)
+
   threads << Thread.new do
-    result = ApiRequest.get(url: ENDPOINT_1,
-                            headers: { Authorization: GenAuth.run })
-    responses << result
-    ResponsesPrinter.print(result)
+    puts "starting batch #{batch.label}"
+    # each batch creates one thread per user
+    batch.run(threads, responses)
   end
-  sleep(opts[:rampup_per_user])
 end
 
 threads.each(&:join)
 
 all_responses = responses.flatten
 
+puts "\n\n"
+puts '-----------------------'
 ResponsesPrinter.print_statistics(all_responses)

--- a/batches.rb
+++ b/batches.rb
@@ -1,0 +1,75 @@
+BATCHES = {
+  default: [
+    { label: 'default', number_of_requests: 1 }
+  ],
+  berwyn: [
+    { label: 'Berwyn GET balances', number_of_users: 20,
+      number_of_requests: 49, interval_between_requests: 74 },
+    { label: 'Berwyn GET tx history', number_of_users: 10,
+      number_of_requests: 19, interval_between_requests: 191 },
+    { label: 'Berwyn POST tx', number_of_users: 15,
+      number_of_requests: 53, interval_between_requests: 69 },
+    { label: 'Berwyn POST pay event', number_of_users: 15,
+      number_of_requests: 18, interval_between_requests: 204 }
+  ],
+  weyland: [
+    { label: 'Weyland GET balances', number_of_users: 10,
+      number_of_requests: 41, interval_between_requests: 89 },
+    { label: 'Weyland GET tx history', number_of_users: 5,
+      number_of_requests: 11, interval_between_requests: 340 },
+    { label: 'Weyland POST tx', number_of_users: 10,
+      number_of_requests: 35, interval_between_requests: 102 },
+    { label: 'Weyland POST pay event', number_of_users: 5,
+      number_of_requests: 24, interval_between_requests: 151 }
+  ],
+  kirklevington: [
+    { label: 'Kirklevington GET balances', number_of_users: 5,
+      number_of_requests: 52, interval_between_requests: 70 },
+    { label: 'Kirklevington GET tx history', number_of_users: 1,
+      number_of_requests: 16, interval_between_requests: 225 },
+    { label: 'Kirklevington POST tx', number_of_users: 2,
+      number_of_requests: 35, interval_between_requests: 103 },
+    { label: 'Kirklevington POST pay event', number_of_users: 3,
+      number_of_requests: 62, interval_between_requests: 58 }
+  ],
+  durham: [
+    { label: 'Durham GET balances', number_of_users: 10,
+      number_of_requests: 54, interval_between_requests: 67 },
+    { label: 'Durham GET tx history', number_of_users: 3,
+      number_of_requests: 28, interval_between_requests: 130 },
+    { label: 'Durham POST tx', number_of_users: 6,
+      number_of_requests: 70, interval_between_requests: 51 },
+    { label: 'Durham POST pay event', number_of_users: 8,
+      number_of_requests: 117, interval_between_requests: 31 }
+  ],
+  holme_house: [
+    { label: 'Holme House GET balances', number_of_users: 10,
+      number_of_requests: 64, interval_between_requests: 56 },
+    { label: 'Holme House GET tx history', number_of_users: 5,
+      number_of_requests: 21, interval_between_requests: 170 },
+    { label: 'Holme House POST tx', number_of_users: 5,
+      number_of_requests: 90, interval_between_requests: 40 },
+    { label: 'Holme House POST pay event', number_of_users: 10,
+      number_of_requests: 120, interval_between_requests: 30 }
+  ],
+  high_down: [
+    { label: 'High Down GET balances', number_of_users: 10,
+      number_of_requests: 56, interval_between_requests: 64 },
+    { label: 'High Down GET tx history', number_of_users: 3,
+      number_of_requests: 30, interval_between_requests: 121 },
+    { label: 'High Down POST tx', number_of_users: 5,
+      number_of_requests: 75, interval_between_requests: 48 },
+    { label: 'High Down POST pay event', number_of_users: 10,
+      number_of_requests: 100, interval_between_requests: 36 }
+  ],
+  cookham_wood: [
+    { label: 'Cookham Wood GET balances', number_of_users: 5,
+      number_of_requests: 49, interval_between_requests: 73 },
+    { label: 'Cookham Wood GET tx history', number_of_users: 1,
+      number_of_requests: 14, interval_between_requests: 257 },
+    { label: 'Cookham Wood POST tx', number_of_users: 2,
+      number_of_requests: 29, interval_between_requests: 126 },
+    { label: 'Cookham Wood POST pay event', number_of_users: 3,
+      number_of_requests: 51, interval_between_requests: 71 }
+  ]
+}.freeze

--- a/command_line_parser.rb
+++ b/command_line_parser.rb
@@ -13,6 +13,13 @@ class CommandLineParser
            'seconds delay between starting each concurrent user') do |r|
         opts[:rampup_per_user] = r.to_i
       end
+      o.on('-b', '--batches=',
+           'comma-separated names of pre-configured batch tests to run') do |b|
+        opts[:batches] = b.to_s.split(',').compact
+      end
+      o.on('-u', '--url=', 'URL to hit') do |u|
+        opts[:url] = u
+      end
       o.on('-h') do
         puts o
         exit 0

--- a/request_group.rb
+++ b/request_group.rb
@@ -1,0 +1,49 @@
+require_relative './httparty_adapter'
+require_relative './api_request'
+require_relative './responses_printer'
+
+# wrapper around a number of concurrent users accessing a given url
+# with a given interval between each request, and between the start
+# of each user
+class RequestGroup
+  attr_accessor :url, :label,
+                :number_of_users, :number_of_requests,
+                :interval_between_requests, :interval_between_users
+
+  def initialize(params = {})
+    self.url = params[:url]
+    self.label = params[:label]
+    self.number_of_requests = params[:number_of_requests] || 1
+    self.number_of_users = params[:number_of_users] || 1
+    self.interval_between_requests = params[:interval_between_requests] || 0
+    self.interval_between_users = params[:interval_between_users] || 0
+  end
+
+  def run(threads, responses)
+    number_of_users.times.each do |user_no|
+      prefix = "[#{label} user #{user_no}]"
+      puts "#{prefix} starting"
+      user_threads = []
+      threads << Thread.new do
+        number_of_requests.times do |request_no|
+          request_prefix = "#{prefix} request #{request_no}"
+          puts "#{request_prefix} starting"
+          begin
+            result = ApiRequest.get(url: url,
+                                    headers: { Authorization: GenAuth.run })
+            responses << result
+            ResponsesPrinter.print(result, request_prefix)
+          rescue Error => e
+            puts "#{request_prefix} exception - #{e.message}"
+          end
+          puts "#{prefix} waiting #{interval_between_requests}s between requests"
+          sleep(interval_between_requests)
+        end
+      end
+      puts "#{prefix} finished"
+      puts "waiting #{interval_between_users}s between users"
+      sleep(interval_between_users)
+    end
+  end
+
+end

--- a/responses_printer.rb
+++ b/responses_printer.rb
@@ -5,11 +5,12 @@ class ResponsesPrinter
     puts 'total_time, code, appserver_time, db_time'
   end
 
-  def self.print(response)
-    puts [response[:total_time],
-          response[:code],
-          response[:appserver_time],
-          response[:db_time]].join(', ')
+  def self.print(response, prefix = nil)
+    puts [prefix,
+          response[:total_time].to_s,
+          response[:code].to_s,
+          response[:appserver_time].to_s,
+          response[:db_time].to_s].compact.join(', ')
   end
 
   def self.print_statistics(all_responses=[])
@@ -19,7 +20,8 @@ class ResponsesPrinter
     end
 
     puts 'Status code counts: '
-    puts count_status_codes(all_responses).join('\n- ')
+    puts count_status_codes(all_responses).join("\n- ")
+    puts "(total #{all_responses.count})"
   end
 
   def self.totals(all_responses)
@@ -46,6 +48,6 @@ class ResponsesPrinter
                        pct: responses.count * 100.0 / all_responses.size.to_f }
     end
     
-    counts.map { |code, count| "#{code}: #{count[:count]} (#{count[:pct]}%)" }
+    counts.map { |code, count| "#{code}: #{count[:count]} (#{sprintf('%.1f', count[:pct])}%)" }
   end
 end


### PR DESCRIPTION
each batch represents a group of requests to be run sequentially.

Batches can be specified using the -b param, and each selected batch will be run in its own thread  (e.g. -b berwyn,weyland). Each batch will then spawn a thread per user, and run the specified number of requests in series, waiting a specified number of seconds between each request.

If no batch parameter is given, a default batch will be used, taking all other params from the command line.
